### PR TITLE
Fix: Double Rhythm Data

### DIFF
--- a/Assets/Core/Scripts/ObjectLauncher.cs
+++ b/Assets/Core/Scripts/ObjectLauncher.cs
@@ -90,7 +90,11 @@ public class ObjectLauncher : MonoBehaviour
         // 발사된 오브젝트에 RhythmData 추가
         if (launchedObject != null)
         {
-            RhythmData rhythmData = launchedObject.AddComponent<RhythmData>();
+            if(!launchedObject.TryGetComponent<RhythmData>(out RhythmData rhythmData))
+            {
+                 rhythmData = launchedObject.AddComponent<RhythmData>(); 
+            }
+
             rhythmData.Initialize(beatTime, isBarrel);
             Debug.Log($"리듬 데이터 추가: 오브젝트 '{launchedObject.name}', 타겟시간 {beatTime}");
         }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/60f0a17b-45ec-4314-8d46-16f68abf957b)
This might occur overwrite Rhythm Data, so It can occur timing error

![image](https://github.com/user-attachments/assets/ee7f9328-3473-4c6b-97a1-e53fc76e0297)
So, check that it has Rhythm data already

Fix #44 